### PR TITLE
Prevent potential resource leak

### DIFF
--- a/src/main/java/com/ticticboooom/mods/mm/client/jei/MMJeiPlugin.java
+++ b/src/main/java/com/ticticboooom/mods/mm/client/jei/MMJeiPlugin.java
@@ -79,12 +79,13 @@ public class MMJeiPlugin implements IModPlugin {
         MANA_TYPE_RENDERER.setHelpers(registration.getJeiHelpers());
         STAR_TYPE_RENDERER.setHelpers(registration.getJeiHelpers());
         ROT_RENDERER.setHelpers(registration.getJeiHelpers());
-        List<MachineStructureRecipe> structureRecipes = Minecraft.getInstance().world.getRecipeManager().getRecipesForType(RecipeTypes.MACHINE_STRUCTURE);
+        Minecraft instance = Minecraft.getInstance();
+        List<MachineStructureRecipe> structureRecipes = instance.world.getRecipeManager().getRecipesForType(RecipeTypes.MACHINE_STRUCTURE);
         for (RegistryObject<ControllerBlock> block : MMLoader.BLOCKS) {
             registration.addRecipes(structureRecipes.stream().filter(x -> x.getControllerId().contains(block.get().getControllerId())).collect(Collectors.toList()), new ResourceLocation(MM.ID, "machine_structure_" + block.get().getControllerId()));
         }
 
-        List<MachineProcessRecipe> processRecipes = Minecraft.getInstance().world.getRecipeManager().getRecipesForType(RecipeTypes.MACHINE_PROCESS);
+        List<MachineProcessRecipe> processRecipes = instance.world.getRecipeManager().getRecipesForType(RecipeTypes.MACHINE_PROCESS);
         for (MachineStructureRecipe structureRecipe : structureRecipes) {
             List<MachineProcessRecipe> recipes = processRecipes.stream().filter(x -> x.getStructureId().equals(structureRecipe.getStructureId())).collect(Collectors.toList());
             registration.addRecipes(recipes, new ResourceLocation(MM.ID, "machine_process_" + structureRecipe.getStructureId()));
@@ -94,10 +95,11 @@ public class MMJeiPlugin implements IModPlugin {
     @Override
     public void registerCategories(IRecipeCategoryRegistration registration) {
         ENERGY_TYPE_RENDERER.setHelpers(registration.getJeiHelpers());
+        Minecraft instance = Minecraft.getInstance();
         for (RegistryObject<ControllerBlock> block : MMLoader.BLOCKS) {
             registration.addRecipeCategories(new MachineStructureRecipeCategory(registration.getJeiHelpers(), block.get()));
         }
-        List<MachineStructureRecipe> structureRecipes = Minecraft.getInstance().world.getRecipeManager().getRecipesForType(RecipeTypes.MACHINE_STRUCTURE);
+        List<MachineStructureRecipe> structureRecipes = instance.world.getRecipeManager().getRecipesForType(RecipeTypes.MACHINE_STRUCTURE);
         for (MachineStructureRecipe structureRecipe : structureRecipes) {
             registration.addRecipeCategories(new MachineProcessRecipeCategory(registration.getJeiHelpers(), structureRecipe.getStructureId(), structureRecipe.getName()));
         }

--- a/src/main/java/com/ticticboooom/mods/mm/client/util/GuiBlockRenderBuilder.java
+++ b/src/main/java/com/ticticboooom/mods/mm/client/util/GuiBlockRenderBuilder.java
@@ -48,7 +48,8 @@ public class GuiBlockRenderBuilder {
 
     public GuiBlockRenderBuilder at(BlockPos position) {
         if (tile != null) {
-            tile.setWorldAndPos(Minecraft.getInstance().world, Minecraft.getInstance().player.getPosition());
+            Minecraft instance = Minecraft.getInstance();
+            tile.setWorldAndPos(instance.world, instance.player.getPosition());
         }
         this.position = position;
         return this;

--- a/src/main/java/com/ticticboooom/mods/mm/datagen/InMemoryPack.java
+++ b/src/main/java/com/ticticboooom/mods/mm/datagen/InMemoryPack.java
@@ -16,7 +16,6 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class InMemoryPack implements IResourcePack {
     private final Path path;
@@ -60,8 +59,7 @@ public class InMemoryPack implements IResourcePack {
             if (!Files.exists(current) || !Files.isDirectory(current)){
                 return;
             }
-            Stream<Path> list = Files.list(current);
-            for (Path child : list.collect(Collectors.toList())) {
+            for (Path child : Files.list(current).collect(Collectors.toList())) {
                 if (!Files.isDirectory(child)) {
                     result.add(new ResourceLocation(currentRLNS, currentRLPath + "/" + child.getFileName()));
                     continue;
@@ -84,11 +82,9 @@ public class InMemoryPack implements IResourcePack {
     public Set<String> getResourceNamespaces(ResourcePackType type) {
         Set<String> result = new HashSet<>();
         try {
-            Stream<Path> list = Files.list(path.resolve(type.getDirectoryName()));
-            for (Path resultingPath : list.collect(Collectors.toList())) {
-                result.add(resultingPath.getFileName().toString());
-            }
-
+            Files.list(path.resolve(type.getDirectoryName()))
+                .map(path -> path.getFileName().toString())
+                .forEach(result::add);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -103,12 +99,11 @@ public class InMemoryPack implements IResourcePack {
         jsonobject.add("pack", packObject);
         if (!jsonobject.has(deserializer.getSectionName())) {
             return null;
-        } else {
-            try {
-                return deserializer.deserialize(JSONUtils.getJsonObject(jsonobject, deserializer.getSectionName()));
-            } catch (JsonParseException jsonparseexception) {
-                return null;
-            }
+        } 
+        try {
+            return deserializer.deserialize(JSONUtils.getJsonObject(jsonobject, deserializer.getSectionName()));
+        } catch (JsonParseException jsonparseexception) {
+            return null;
         }
     }
 

--- a/src/main/java/com/ticticboooom/mods/mm/helper/StructureHelper.java
+++ b/src/main/java/com/ticticboooom/mods/mm/helper/StructureHelper.java
@@ -99,7 +99,8 @@ public class StructureHelper {
                 .setPrettyPrinting()
                 .disableHtmlEscaping()
                 .create().toJson(jsonObject);
-        Minecraft.getInstance().keyboardListener.setClipboardString(s);
+        Minecraft instance = Minecraft.getInstance();
+        instance.keyboardListener.setClipboardString(s);
     }
 
     private static JsonObject toJson(Map<Character, ResourceLocation> legend, List<List<String>> layout) {

--- a/src/main/java/com/ticticboooom/mods/mm/network/packets/TileClientUpdatePacket.java
+++ b/src/main/java/com/ticticboooom/mods/mm/network/packets/TileClientUpdatePacket.java
@@ -32,7 +32,8 @@ public class TileClientUpdatePacket {
 
     public static void handle(Data data, Supplier<NetworkEvent.Context> ctx) {
         ctx.get().enqueueWork(() -> {
-            ClientWorld level = Minecraft.getInstance().world;
+            Minecraft instance = Minecraft.getInstance();
+            ClientWorld level = instance.world;
             TileEntity blockEntity = level.getTileEntity(data.getPos());
             BlockState state = level.getBlockState(data.getPos());
             if (blockEntity != null) {

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/EnergyPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/EnergyPortStorage.java
@@ -55,7 +55,8 @@ public class EnergyPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0,  175, 256);
         int barX = left + 175 - 30;
         int barY = top + 20;
@@ -67,7 +68,7 @@ public class EnergyPortStorage extends PortStorage {
             pct = (float)inv.getEnergyStored() / inv.getMaxEnergyStored();
         }
         GuiHelper.renderVerticallyFilledBar(stack, screen, barX, barY, 193, 18, barWidth, barHeight, pct);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer,String.format("%.2f",Math.round((float)10000 * pct) / 100.f) + "%", left + 30, top + 60, 0xfefefe);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getEnergyStored() + "FE", left + 30, top + 80, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer,String.format("%.2f",Math.round((float)10000 * pct) / 100.f) + "%", left + 30, top + 60, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getEnergyStored() + "FE", left + 30, top + 80, 0xfefefe);
     }
 }

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/FluidPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/FluidPortStorage.java
@@ -62,7 +62,8 @@ public class FluidPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0, 175, 256);
         int x = 78;
         int y = 40;
@@ -71,7 +72,7 @@ public class FluidPortStorage extends PortStorage {
         if (!fluid.isEmpty()){
             FluidRenderer.INSTANCE.render(stack, left + x + 1, top + y + 1, inv.getFluidInTank(0), 16);
 
-            AbstractGui.drawCenteredString(stack, Minecraft.getInstance().fontRenderer, inv.getFluidInTank(0).getAmount() + " " + inv.getFluidInTank(0).getDisplayName().getString(), left + x + 9 + 1, top + y + 30, 0xfefefe);
+            AbstractGui.drawCenteredString(stack, instance.fontRenderer, inv.getFluidInTank(0).getAmount() + " " + inv.getFluidInTank(0).getDisplayName().getString(), left + x + 9 + 1, top + y + 30, 0xfefefe);
         }
     }
 

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/ItemPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/ItemPortStorage.java
@@ -67,7 +67,8 @@ public class ItemPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0, 175, 256);
         int offsetY = ((108 - (rows * 18)) / 2) + 7;
         int offsetX = ((162 - (columns * 18)) / 2) + 7;

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/ManaPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/ManaPortStorage.java
@@ -54,7 +54,8 @@ public class ManaPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/mana_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/mana_gui.png"));
         screen.blit(stack, left, top, 0, 0,  175, 256);
         int barOffsetX = 175 - 30;
         int barOffsetY = 20;
@@ -68,6 +69,6 @@ public class ManaPortStorage extends PortStorage {
             pct = (float)inv.getManaStored() / inv.getMaxManaStored();
         }
         GuiHelper.renderVerticallyFilledBar(stack, screen, barX, barY, 193, 18, barWidth, barHeight, pct);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getManaStored() + " Mana", left + 30, top + 60, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getManaStored() + " Mana", left + 30, top + 60, 0xfefefe);
     }
 }

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/MekGasPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/MekGasPortStorage.java
@@ -63,7 +63,8 @@ public class MekGasPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0,  175, 256);
         int barX = left + 175 - 30;
         int barY = top + 20;
@@ -75,8 +76,8 @@ public class MekGasPortStorage extends PortStorage {
             pct = (float)inv.getStack().getAmount() / inv.getTankCapacity(0);
         }
         GuiHelper.renderVerticallyFilledBar(stack, screen, barX, barY, 193, 18, barWidth, barHeight, pct);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer,inv.getStack().getType().getTextComponent().getString(), left + 30, top + 60, 0xfefefe);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getStack().getAmount() + "mB", left + 30, top + 80, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer,inv.getStack().getType().getTextComponent().getString(), left + 30, top + 60, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getStack().getAmount() + "mB", left + 30, top + 80, 0xfefefe);
 
     }
 }

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/MekInfusePortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/MekInfusePortStorage.java
@@ -64,7 +64,8 @@ public class MekInfusePortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0, 175, 256);
         int barX = left + 175 - 30;
         int barY = top + 20;
@@ -76,7 +77,7 @@ public class MekInfusePortStorage extends PortStorage {
             pct = (float) inv.getStack().getAmount() / inv.getTankCapacity(0);
         }
         GuiHelper.renderVerticallyFilledBar(stack, screen, barX, barY, 193, 18, barWidth, barHeight, pct);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getStack().getType().getTextComponent().getString(), left + 30, top + 60, 0xfefefe);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getStack().getAmount() + "mB", left + 30, top + 80, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getStack().getType().getTextComponent().getString(), left + 30, top + 60, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getStack().getAmount() + "mB", left + 30, top + 80, 0xfefefe);
     }
 }

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/MekPigmentPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/MekPigmentPortStorage.java
@@ -64,7 +64,8 @@ public class MekPigmentPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0, 175, 256);
         int barX = left + 175 - 30;
         int barY = top + 20;
@@ -76,7 +77,7 @@ public class MekPigmentPortStorage extends PortStorage {
             pct = (float) inv.getStack().getAmount() / inv.getTankCapacity(0);
         }
         GuiHelper.renderVerticallyFilledBar(stack, screen, barX, barY, 193, 18, barWidth, barHeight, pct);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getStack().getType().getTextComponent().getString(), left + 30, top + 60, 0xfefefe);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getStack().getAmount() + "mB", left + 30, top + 80, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getStack().getType().getTextComponent().getString(), left + 30, top + 60, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getStack().getAmount() + "mB", left + 30, top + 80, 0xfefefe);
     }
 }

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/MekSlurryPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/MekSlurryPortStorage.java
@@ -64,7 +64,8 @@ public class MekSlurryPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0, 175, 256);
         int barX = left + 175 - 30;
         int barY = top + 20;
@@ -76,8 +77,8 @@ public class MekSlurryPortStorage extends PortStorage {
             pct = (float) inv.getStack().getAmount() / inv.getTankCapacity(0);
         }
         GuiHelper.renderVerticallyFilledBar(stack, screen, barX, barY, 193, 18, barWidth, barHeight, pct);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getStack().getType().getTextComponent().getString(), left + 30, top + 60, 0xfefefe);
-        AbstractGui.drawString(stack, Minecraft.getInstance().fontRenderer, inv.getStack().getAmount() + "mB", left + 30, top + 80, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getStack().getType().getTextComponent().getString(), left + 30, top + 60, 0xfefefe);
+        AbstractGui.drawString(stack, instance.fontRenderer, inv.getStack().getAmount() + "mB", left + 30, top + 80, 0xfefefe);
 
     }
 }

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/PneumaticPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/PneumaticPortStorage.java
@@ -76,7 +76,8 @@ public class PneumaticPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0, 175, 256);
         int barX = left + 175 - 30;
         int barY = top + 20;
@@ -87,8 +88,8 @@ public class PneumaticPortStorage extends PortStorage {
         float pct = inv.getPressure() / inv.getCriticalPressure();
         GuiHelper.renderVerticallyFilledBar(stack, screen, barX, barY, 193, 18, barWidth, barHeight, pct);
 
-        AbstractGui.drawCenteredString(stack, Minecraft.getInstance().fontRenderer, NumberFormat.getInstance().format(inv.getPressure()) + " bar", left + 50, top + 80, 0xfefefe);
-        AbstractGui.drawCenteredString(stack, Minecraft.getInstance().fontRenderer, inv.getAir() + " mL", left + 50, top + 60, 0xfefefe);
+        AbstractGui.drawCenteredString(stack, instance.fontRenderer, NumberFormat.getInstance().format(inv.getPressure()) + " bar", left + 50, top + 80, 0xfefefe);
+        AbstractGui.drawCenteredString(stack, instance.fontRenderer, inv.getAir() + " mL", left + 50, top + 60, 0xfefefe);
 
     }
 

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/RotationPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/RotationPortStorage.java
@@ -66,9 +66,10 @@ public class RotationPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0, 175, 256);
-        AbstractGui.drawCenteredString(stack, Minecraft.getInstance().fontRenderer, speed + " Speed", left + 60, top + 30, 0xfefefe);
+        AbstractGui.drawCenteredString(stack, instance.fontRenderer, speed + " Speed", left + 60, top + 30, 0xfefefe);
     }
 
     @Override

--- a/src/main/java/com/ticticboooom/mods/mm/ports/storage/StarlightPortStorage.java
+++ b/src/main/java/com/ticticboooom/mods/mm/ports/storage/StarlightPortStorage.java
@@ -49,8 +49,9 @@ public class StarlightPortStorage extends PortStorage {
 
     @Override
     public void render(MatrixStack stack, int mouseX, int mouseY, int left, int top, Screen screen) {
-        Minecraft.getInstance().textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
+        Minecraft instance = Minecraft.getInstance();
+        instance.textureManager.bindTexture(new ResourceLocation(MM.ID, "textures/gui/port_gui.png"));
         screen.blit(stack, left, top, 0, 0, 175, 256);
-        AbstractGui.drawCenteredString(stack, Minecraft.getInstance().fontRenderer, inv.getStarlightStored() + " Starlight", left + 60, top + 30, 0xfefefe);
+        AbstractGui.drawCenteredString(stack, instance.fontRenderer, inv.getStarlightStored() + " Starlight", left + 60, top + 30, 0xfefefe);
     }
 }


### PR DESCRIPTION
This PR: 
1. extract Minecraft.getInstance() to variables to prevent potential resource leak. This is reported by VSCode. 
2. avoid assigning Stream to variables, so that we don't to manually call close(). 